### PR TITLE
Update Typos and display sort in Partners

### DIFF
--- a/src/containers/PartnersSection.tsx
+++ b/src/containers/PartnersSection.tsx
@@ -29,7 +29,7 @@ const PartnersSection = ({ partners }: PartnersProps) => {
                 <h5 className="mb-2 text-center">
                   <a className="text-dark">{item.name}</a>
                 </h5>
-                <p className="position text-muted" style={{ textAlign: "justify" }}>{item.description}</p>
+                <p className="position text-muted" style={{ textAlign: "left" }}>{item.description}</p>
               </div>
             </div>
           </div>

--- a/src/pages/Partners.tsx
+++ b/src/pages/Partners.tsx
@@ -7,14 +7,14 @@ import PartnersSection, {partner} from "../containers/PartnersSection";
 
 const partners: partner[] = [
   {
+    logo: partnerLogo2,
+    name: "HUI O HAU‘ULA",
+    description: "A community-driven collective uniting local businesses, organizations, and outreach programs to empower keiki, \"ohana, and kupuna\". As a Partnership Hub, they expand access to essential services like health, education, food security, and cultural preservation.",
+  },
+  {
     logo: partnerLogo1,
     name: "Kids Hurt Too Hawaii",
     description: "Providing free support for children and youth (3-19) facing grief and trauma. Through mentorship, crisis care, and peer groups, they help families heal and rebuild.",
-  },
-  {
-    logo: partnerLogo2,
-    name: "HUI O HAU‘ULA",
-    description: "A community-driven collective uniting local businesses, organizations, and outreach programs to empower keiki, ‘ohana, and kūpuna. As a Partnership Hub, they expand access to essential services like health, education, food security, and cultural preservation.",
   },
 ];
 
@@ -25,7 +25,7 @@ const PartnersPage = () => {
       <HeroPage
         imagen={partnersImage}
         page="Stronger Together: Our Partners"
-        description='At Corazón Hawaii, we believe in the power of collaboration. By working alongside dedicated organizations, we expand our impact, providing essential resources, housing solutions, and community support.'
+        description='At Corazon Hawaii, we believe in the power of collaboration. By working alongside dedicated organizations, we expand our impact, providing essential resources, housing solutions, and community support.'
         Breadcrumb={[{ link: "/", nombre: "Home" }]}
       />
       <section className="section">


### PR DESCRIPTION
# Update Typos and display sort in Partners
----
- Remove special characters in  “ohana, and kupuna”.
- Remove text justify in partner description
- Change partner's order :
- - 1 .- Hui o Hau
- - 2.- Kids Hurt
- Remove accent from `corazon`